### PR TITLE
Fix kicking cubes

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -394,7 +394,7 @@ char* Player::getHUDString() {
 }
 
 void Player::kickCube() {
-	GreedyCoords current = m_grid->transformRealToGreedy((RealCoords){m_x, m_y + 0.9f, m_z});
+	GreedyCoords current = m_grid->transformRealToGreedy((RealCoords){m_x, m_y + 0.5f, m_z});
 	GreedyCoords chosen = m_grid->transformRealToGreedy(m_chosenCoords);
 
 	if (current.y != chosen.y) {


### PR DESCRIPTION
The Y_DIST added to m_y after falling collision check changed the position of
the kick hit to be at the layer above the player (You can check it by
placing on cube on the next level and kick after jumping). It was working but was
hitting the next layer. Changed to be at about the body level.